### PR TITLE
exception handling for frames where we can't calculate midline

### DIFF
--- a/hydracv/fluorescence/trace_fluo.py
+++ b/hydracv/fluorescence/trace_fluo.py
@@ -19,6 +19,7 @@ def trace(video, contours=[], display=True):
     cap = cv2.VideoCapture(video)
     firstf = True
     iframe = 0
+
     while True:
         # Capture frame-by-frame
         ret, frame = cap.read()
@@ -37,14 +38,17 @@ def trace(video, contours=[], display=True):
                     break
                     
                 curr_contour = contours[iframe]
-                # Create a mask that keeps only pixels w/in hydra contour
-                contour_mask = np.ones(frame.shape)
-                poly = np.array(curr_contour, dtype=np.int32)
-                cv2.fillConvexPoly(contour_mask,poly,0)
- 
-                frame = np.ma.masked_array(frame, mask=contour_mask)
-    
-            intensity = np.sum(frame)
+                
+                if not curr_contour:
+                    print(f'No polygon found; setting intensity to 0 for {iframe}.')
+                    intensity = 0
+                else:
+                    # Create a mask that keeps only pixels w/in hydra contour
+                    contour_mask = np.ones(frame.shape)
+                    poly = np.array(curr_contour, dtype=np.int32)
+                    cv2.fillConvexPoly(contour_mask,poly,0)
+                    frame = np.ma.masked_array(frame, mask=contour_mask)
+                    intensity = np.sum(frame)
             intensities_.append(intensity)
 
             # Display the resulting frame

--- a/hydracv/midline/find_midline_midpoints.py
+++ b/hydracv/midline/find_midline_midpoints.py
@@ -130,8 +130,8 @@ def extract_midline(contour, marker_mat, nseg=20, play=False):
     contour_half_2 = np.array([contour[0]] + contour[ind_arp2:][::-1])
 
     if len(contour_half_1) == 0 or len(contour_half_2) == 0:
-        # continue
-        raise Exception("Half contour is 0")
+        # DLC markers are inaccurate; e.g. the armpit markers are on top of each other
+        raise Exception("Half contour is 0.")
 
 
     # Find the midpoints
@@ -195,8 +195,12 @@ def find_midline(file_contour, file_marker, file_video="", nseg=40, play=False):
         # Extract contour and marker
         contour = contours[iframe]
         marker_mat = markers[iframe]
-
-        midpoints, _, _ = extract_midline(contour, marker_mat, nseg, play)
+        try:
+            midpoints, _, _ = extract_midline(contour, marker_mat, nseg, play)
+        except Exception as excep:
+            print(f'Unable to calculate midline for frame {iframe}.')
+            # Can't accurately calculate midpoints, so pass in empty lists as placeholders
+            midpoints, _, _ = [],[],[]
         midpoints_all.append(midpoints)
 
     return midpoints_all


### PR DESCRIPTION
happens when DLC markers are unusable, e.g. when the two armpits overlap